### PR TITLE
ci: configure Git author in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,10 @@ jobs:
         run: sudo apt install -y libxml-xpath-perl
       - name: Prepare and perform release
         run: |
+          git config --global committer.email "48418865+dropwizard-committers@users.noreply.github.com"
+          git config --global committer.name "Release Action"
+          git config --global author.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global author.name "${GITHUB_ACTOR}"
           VERSION=$(xpath -q -e '/project/properties/flywayVersion/text()' pom.xml)
           ./mvnw -B -V -ntp -DreleaseVersion="${VERSION}" release:prepare release:perform
         env:


### PR DESCRIPTION
```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:3.1.1:prepare (default-cli) on project flyway-bom: Unable to commit files
Error:  Provider message:
Error:  The git-commit command failed.
Error:  Command output:
Error:  Author identity unknown
Error:  
Error:  *** Please tell me who you are.
```